### PR TITLE
Unpun SingleSelect and Selectable events

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -185,11 +185,13 @@ The following events are triggered from Selectable models
 
 #### "selected"
 
-Triggers when a model is selected. 
+Triggers when a model is selected. Provides the selected model
+as the first parameter.
 
 #### "deselected"
 
-Triggers when a model is deselected.
+Triggers when a model is deselected. Provides the selected model
+as the first parameter.
 
 ## Picky.SingleSelect
 
@@ -292,15 +294,15 @@ myCol.selected; //=> model
 
 ### SingleSelect Events
 
-The following events are triggered by the MultiSelect based on changes
+The following events are triggered by the SingleSelect based on changes
 in selection:
 
-#### "selected"
+#### "select:one"
 
 Triggered when a model has been selected. Provides the selected model
 as the first parameter.
 
-#### "deselected"
+#### "deselect:one"
 
 Triggered when a model has been deselected. Provides the deselected model
 as the first parameter.

--- a/spec/javascripts/selectable.spec.js
+++ b/spec/javascripts/selectable.spec.js
@@ -21,7 +21,7 @@ describe("selectable model", function(){
     });
 
     it("should notify of selection", function(){
-      expect(model.trigger).toHaveBeenCalledWith("selected");
+      expect(model.trigger).toHaveBeenCalledWith("selected", model);
     });
   });
 
@@ -61,7 +61,7 @@ describe("selectable model", function(){
     });
 
     it("should notify of deselection", function(){
-      expect(model.trigger).toHaveBeenCalledWith("deselected");
+      expect(model.trigger).toHaveBeenCalledWith("deselected", model);
     });
   });
 

--- a/spec/javascripts/singleSelect.spec.js
+++ b/spec/javascripts/singleSelect.spec.js
@@ -23,6 +23,7 @@ describe("single select collection", function(){
       model = new Model();
       collection = new Collection([model]);
 
+      spyOn(model, "trigger").andCallThrough();
       spyOn(collection, "trigger").andCallThrough();
 
       model.select();
@@ -33,7 +34,11 @@ describe("single select collection", function(){
     });
 
     it("should trigger a selected event", function(){
-      expect(collection.trigger).toHaveBeenCalledWith("selected", model);
+      expect(model.trigger).toHaveBeenCalledWith("selected", model);
+    });
+
+    it("should trigger a collection selected event", function(){
+      expect(collection.trigger).toHaveBeenCalledWith("select:one", model);
     });
   });
 
@@ -55,7 +60,7 @@ describe("single select collection", function(){
     });
 
     it("should trigger a selected event", function(){
-      expect(collection.trigger).toHaveBeenCalledWith("selected", model);
+      expect(collection.trigger).toHaveBeenCalledWith("select:one", model);
     });
 
     it("should tell the model to select itself", function(){
@@ -78,7 +83,7 @@ describe("single select collection", function(){
     });
 
     it("should not trigger a selected event", function(){
-      expect(collection.trigger).not.toHaveBeenCalledWith("selected", model);
+      expect(collection.trigger).not.toHaveBeenCalledWith("select:one", model);
     });
   });
 
@@ -102,7 +107,7 @@ describe("single select collection", function(){
     });
 
     it("should trigger a selected event", function(){
-      expect(collection.trigger).toHaveBeenCalledWith("selected", m2);
+      expect(collection.trigger).toHaveBeenCalledWith("select:one", m2);
     });
 
     it("should deselect the first model", function(){
@@ -110,7 +115,7 @@ describe("single select collection", function(){
     });
 
     it("should fire a deselect event for the first model", function(){
-      expect(collection.trigger).toHaveBeenCalledWith("deselected", m1);
+      expect(collection.trigger).toHaveBeenCalledWith("deselect:one", m1);
     });
   });
 
@@ -148,7 +153,7 @@ describe("single select collection", function(){
     });
 
     it("should trigger a deselected event", function(){
-      expect(collection.trigger).toHaveBeenCalledWith("deselected", model);
+      expect(collection.trigger).toHaveBeenCalledWith("deselect:one", model);
     });
   });
 
@@ -180,11 +185,11 @@ describe("single select collection", function(){
     });
 
     it("should not trigger a deselected event for the selected model", function(){
-      expect(collection.trigger).not.toHaveBeenCalledWith("deselected", m1);
+      expect(collection.trigger).not.toHaveBeenCalledWith("deselect:one", m1);
     });
 
     it("should not trigger a deselected event for the non-selected model", function(){
-      expect(collection.trigger).not.toHaveBeenCalledWith("deselected", m2);
+      expect(collection.trigger).not.toHaveBeenCalledWith("deselect:one", m2);
     });
   });
 
@@ -216,11 +221,11 @@ describe("single select collection", function(){
     });
 
     it("should not trigger a deselected event for the selected model", function(){
-      expect(collection.trigger).not.toHaveBeenCalledWith("deselected", m1);
+      expect(collection.trigger).not.toHaveBeenCalledWith("deselect:one", m1);
     });
 
     it("should not trigger a deselected event for the non-selected model", function(){
-      expect(collection.trigger).not.toHaveBeenCalledWith("deselected", m2);
+      expect(collection.trigger).not.toHaveBeenCalledWith("deselect:one", m2);
     });
   });
 

--- a/src/backbone.picky.js
+++ b/src/backbone.picky.js
@@ -15,7 +15,7 @@ Backbone.Picky = (function (Backbone, _) {
   _.extend(Picky.SingleSelect.prototype, {
 
     // Select a model, deselecting any previously
-    // select model
+    // selected model
     select: function(model){
       if (model && this.selected === model) { return; }
 
@@ -23,7 +23,7 @@ Backbone.Picky = (function (Backbone, _) {
 
       this.selected = model;
       this.selected.select();
-      this.trigger("selected", model);
+      this.trigger("select:one", model);
     },
 
     // Deselect a model, resulting in no model
@@ -35,7 +35,7 @@ Backbone.Picky = (function (Backbone, _) {
       if (this.selected !== model){ return; }
 
       this.selected.deselect();
-      this.trigger("deselected", this.selected);
+      this.trigger("deselect:one", this.selected);
       delete this.selected;
     }
 
@@ -118,7 +118,7 @@ Backbone.Picky = (function (Backbone, _) {
       if (this.selected) { return; }
 
       this.selected = true;
-      this.trigger("selected");
+      this.trigger("selected", this);
 
       if (this.collection) {
         this.collection.select(this);
@@ -131,7 +131,7 @@ Backbone.Picky = (function (Backbone, _) {
       if (!this.selected) { return; }
 
       this.selected = false;
-      this.trigger("deselected");
+      this.trigger("deselected", this);
 
       if (this.collection) {
         this.collection.deselect(this);


### PR DESCRIPTION
Both `SingleSelect` and `Selectable` fire `selected` and `deselected` 
events, making event capture on a collection more difficult, as you get 
twice the events you want, with different parameters.

Update Selectable's `selected` and `deselected` events to provide the 
model as its first parameter (like how the collection `selected` event 
behaved previously).

Change `SingleSelect` to fire `select:one` and `deselect:one` events 
instead of the `selected` and `deselected` events. This is roughly 
similar to the namespacing of the `MultiSelect` and so maintains a 
foolish consistency.

Also:
- Update the tests
- Update the Readme documentation
