### PR TITLE
Setup proper bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "backbone.picky",
+  "version": "0.2.0",
+  "homepage": "https://github.com/derickbailey/backbone.picky",
+  "authors": [
+    "Derick Bailey <derickbailey@gmail.com>"
+  ],
+  "description": "selectable entities as mixins for Backbone.Model and Backbone.Collection",
+  "main": "lib/backbone.picky.js",
+  "keywords": [
+    "backbone"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "Gruntfile.js",
+    "node_modules",
+    "bower_components",
+    "test",
+    "public",
+    "reports",
+    "spec",
+    "src",
+    "tests"
+  ]
+}


### PR DESCRIPTION
This PR adds a properly setup bower.json file with ignored directories and files. Should fix #20. A version bump after this would put it into effect.
