### PR TITLE
Update readme to fix misnamed function.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -389,14 +389,14 @@ Models that are not currently selected will be selected.
 The end result will be all models in the collection are
 selected.
 
-#### MultiSelect#deselectAll
+#### MultiSelect#selectNone
 
 Deselect all models in the collection.
 
 ```js
 myCol = new MultiCollection();
 
-myCol.deselectAll();
+myCol.selectNone();
 ```
 
 Models that are selected will be deselected. 


### PR DESCRIPTION
- The readme mentions the #deselectAll function but it should be called #selectNone
