### PR TITLE
updated model listening examples to be inline with API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,7 @@ triggering a "select" event.
 ```js
 var myModel = new SelectableModel();
 
-myModel.on("select", function(){
+myModel.on("selected", function(){
   console.log("I'm selected!");
 });
 
@@ -157,7 +157,7 @@ the `select` or `deselect` method appropriately.
 ```js
 var myModel = new SelectableModel();
 
-myModel.on("select", function(){
+myModel.on("selected", function(){
   console.log("I'm selected!");
 });
 


### PR DESCRIPTION
Picky triggers  `this.trigger("selected", this);` on the model but the example listened for `select`, just changed the readme to reflect this
