### PR TITLE
add a main file to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "backbone.picky",
   "version": "0.2.0",
   "dependencies": {},
+  "main": "lib/amd/backbone.picky.js",
   "devDependencies": {
     "matchdep": "~0.1.2",
     "grunt": "~0.4.1",


### PR DESCRIPTION
This will allow this module to be used with browserify builds and other commonjs environments that rely on package.json to resolve the main file.
